### PR TITLE
:memo:  Update Gene_expression_regression.ipynb

### DIFF
--- a/3.Regression_gene_expression/Gene_expression_regression.ipynb
+++ b/3.Regression_gene_expression/Gene_expression_regression.ipynb
@@ -9,7 +9,7 @@
     "import pandas as pd\n",
     "import numpy as np\n",
     "from sklearn.model_selection import train_test_split\n",
-    "import keras\n",
+    "from tensorflow import keras\n",
     "from keras.datasets import mnist\n",
     "from keras.models import Sequential\n",
     "from keras.layers import Dense, Dropout\n",


### PR DESCRIPTION
"from tensorflow import keras\n",  instead of   "import keras\n"

to avoid 
                AttributeError: module 'keras.optimizers' has no attribute 'Adam'
When compiling the Model